### PR TITLE
Show VM consoles in an iframe where possible

### DIFF
--- a/assets/dist/css/client.css
+++ b/assets/dist/css/client.css
@@ -6,6 +6,28 @@ a.k_disabled {
 }
 
 /**
+VM Console inline frame
+ */
+#kvm-console {
+    width: 100%;
+    padding-top: 60%;
+    position: relative;
+    overflow: hidden;
+    box-shadow: rgba(0, 0, 0, 0.3) 0 0 10px;
+}
+
+#kvm-console iframe {
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    border: none;
+    right: 0;
+    left: 0;
+    top: 0;
+    bottom: 0;
+}
+
+/**
 This is a badge displaying the VM's state, ie 'started', 'stopped', 'unknown'
  */
 .kvm-state {

--- a/lib/Adaptation/ClientArea.php
+++ b/lib/Adaptation/ClientArea.php
@@ -17,8 +17,8 @@ class ClientArea
 		$jsPath = OverrideHelper::asset('dist/js/client.js');
 
 		return <<<HTML
-<link href="{$baseUrl}/modules/servers/katapult/{$cssPath}" rel="stylesheet" type="text/css" />
-<script type="text/javascript" defer src="{$baseUrl}/modules/servers/katapult/{$jsPath}"></script>
+<link href="{$baseUrl}/modules/servers/katapult/{$cssPath}?1617183192" rel="stylesheet" type="text/css" />
+<script type="text/javascript" defer src="{$baseUrl}/modules/servers/katapult/{$jsPath}?1617183192"></script>
 <script type="text/javascript">const knrpToken = "{$replayToken}";</script>
 HTML;
 	}

--- a/views/client/virtual_machines/overview.tpl
+++ b/views/client/virtual_machines/overview.tpl
@@ -30,7 +30,7 @@
 
             <h5 style="margin-top: 2rem">Console access</h5>
 
-            <form method="get">
+            <form method="get" target="kvm_console">
 
                 <input type="hidden" name="action" value="productdetails">
                 <input type="hidden" name="id" value="{$id|htmlentities}">
@@ -63,6 +63,16 @@
                 <button class="btn btn-secondary btn-sm" type="button" id="kvm_password_toggle" style="margin-top: 0.5rem"></button>
 
             </div>
+
+        </div>
+
+    </div>
+
+    <div class="row">
+
+        <div class="col-md-12">
+
+            <iframe title="Console" name="kvm_console"></iframe>
 
         </div>
 

--- a/views/client/virtual_machines/overview.tpl
+++ b/views/client/virtual_machines/overview.tpl
@@ -11,7 +11,7 @@
 
     <div class="row">
 
-        <div class="col-md-6 col-sm-12">
+        <div class="col-md-6 col-sm-12" style="margin-bottom: 2rem">
 
             <h5>Server state</h5>
             <span class="kvm-state state--{$katapultVmService['vm']['state']|htmlentities} for-template--{$template|htmlentities}">{$katapultVmService['vm']['state']|replace:'_':' '|htmlentities}</span>
@@ -27,21 +27,6 @@
                 <small>SSH is available on most servers, and is the preferred way to login.</small>
 
             {/if}
-
-            <h5 style="margin-top: 2rem">Console access</h5>
-
-            <form method="get" target="kvm_console">
-
-                <input type="hidden" name="action" value="productdetails">
-                <input type="hidden" name="id" value="{$id|htmlentities}">
-                <input type="hidden" name="dosinglesignon" value="1">
-                <input type="hidden" name="knrp" value="{WHMCS\Module\Server\Katapult\Helpers\Replay::getToken()|htmlentities}">
-
-                <button class="btn btn-primary">Launch console</button>
-
-            </form>
-
-            <small>The console can be used to access the server when the network is unavailable.</small>
 
         </div>
 
@@ -72,7 +57,32 @@
 
         <div class="col-md-12">
 
-            <iframe title="Console" name="kvm_console"></iframe>
+            <form method="get" id="kvm-console-launcher">
+
+                <h5 style="margin-top: 2rem">Console access</h5>
+
+                <input type="hidden" name="action" value="productdetails">
+                <input type="hidden" name="id" value="{$id|htmlentities}">
+                <input type="hidden" name="dosinglesignon" value="1">
+                <input type="hidden" name="knrp" value="{WHMCS\Module\Server\Katapult\Helpers\Replay::getToken()|htmlentities}">
+
+                <button class="btn btn-primary" type="button">Launch console</button>
+
+                <br><small>The console can be used to access the server when the network is unavailable.</small>
+
+            </form>
+
+        </div>
+
+        <div class="col-md-12 d-none hidden" id="kvm-console-container">
+
+            <h5 style="margin-top: 2rem">Console</h5>
+
+            <div id="kvm-console">
+
+                <iframe title="Console" name="kvm_console"></iframe>
+
+            </div>
 
         </div>
 


### PR DESCRIPTION
This will launch VM consoles in an iframe where the users browser is > 500px wide. Less than that and the UI isn't going to be usable, and they will instead launch in a new window.

This feature is pending support from Katapult to allow the frame to be embedded into other domains.

Closes #20 