### PR TITLE
fix: console iframe cut-off, replay protection, add full screen console view

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: en-GB
+
+reviews:
+  high_level_summary: false
+  review_status: false
+  commit_status: false
+  changed_files_summary: false
+  request_changes_workflow: false
+  sequence_diagrams: false
+  suggested_labels: false
+  suggested_reviewers: false
+  in_progress_fortune: false
+  poem: false
+  enable_prompt_for_ai_agents: true
+  pre_merge_checks:
+    title:
+      mode: 'off'
+    description:
+      mode: 'off'
+  path_instructions:
+    - path: '**/*'
+      instructions: |
+        - Do not mark the PR as request changes for nitpick level comments.
+
+chat:
+  art: false
+
+code_generation:
+  docstrings:
+    language: en-GB

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ USER_ID=$(shell id -u)
 GROUP_ID=$(shell id -g)
 CURRENT_DIR=$(shell pwd)
 
-.PHONY: build install update build-server-module
+.PHONY: build install test update build-server-module
 
 build:
 	docker build -t $(DOCKER_IMAGE) .
@@ -13,6 +13,9 @@ install:
 
 update:
 	docker run -u "$(USER_ID):$(GROUP_ID)" -v "$(CURRENT_DIR):/app" -w /app $(DOCKER_IMAGE) composer update
+
+test:
+	docker run -u "$(USER_ID):$(GROUP_ID)" -v "$(CURRENT_DIR):/app" -w /app $(DOCKER_IMAGE) composer test
 
 build-server-module:
 	docker run -u "$(USER_ID):$(GROUP_ID)" -v "$(CURRENT_DIR):/app" -w /app $(DOCKER_IMAGE) ./bin/katapult build:server-module

--- a/README.md
+++ b/README.md
@@ -69,3 +69,23 @@ The `build:server-module` command does all this for you.
 ```
 
 This creates a `katapult.zip` file in your `build` directory and outputs the full path.
+
+### Running tests
+
+See the Makefile for details. First, build the docker image:
+
+```shell
+make build
+```
+
+Install composer dependencies:
+
+```shell
+make install
+```
+
+Then you can run the test suite:
+
+```shell
+make test
+```

--- a/assets/dist/css/client.css
+++ b/assets/dist/css/client.css
@@ -9,22 +9,34 @@ a.k_disabled {
 VM Console inline frame
  */
 #kvm-console {
+    /* The console page enforces min-width:1200px. Rather than scale the whole
+       thing down (which makes the text console illegible), give it a fixed
+       viewport and let the user scroll to reach the parts that overflow. */
     width: 100%;
-    padding-top: 60%;
+    height: 700px;
     position: relative;
-    overflow: hidden;
+    overflow: auto;
     box-shadow: rgba(0, 0, 0, 0.3) 0 0 10px;
 }
 
 #kvm-console iframe {
+    /* Rendered 1:1 at the page's native width so text stays crisp. */
+    width: 1200px;
+    height: 900px;
+    border: none;
+    display: block;
+}
+
+/* When the console is fullscreen, let the iframe fill the whole viewport
+   instead of staying at its fixed inline size. */
+#kvm-console:fullscreen {
+    height: 100%;
+    overflow: hidden;
+}
+
+#kvm-console:fullscreen iframe {
     width: 100%;
     height: 100%;
-    position: absolute;
-    border: none;
-    right: 0;
-    left: 0;
-    top: 0;
-    bottom: 0;
 }
 
 /**
@@ -113,5 +125,3 @@ Building
     50% { background-color: #ffffff; }
     to { background-color: #0043b3; }
 }
-
-

--- a/assets/dist/js/client.js
+++ b/assets/dist/js/client.js
@@ -134,6 +134,21 @@ if(typeof kvmService === 'object') {
             const launchForm = document.getElementById('kvm-console-launcher')
             const launchButton = launchForm.querySelector('button')
 
+            // The console page enforces a min-width of 1200px. In the inline
+            // box it renders 1:1 with a scrollbar (see client.css); fullscreen
+            // gives it the whole viewport so nothing needs scrolling.
+            const kvmConsole = document.getElementById('kvm-console');
+            const fullscreenButton = document.getElementById('kvm-console-fullscreen')
+            if (fullscreenButton) {
+                fullscreenButton.addEventListener('click', () => {
+                    if (document.fullscreenElement) {
+                        document.exitFullscreen();
+                    } else {
+                        kvmConsole.requestFullscreen();
+                    }
+                })
+            }
+
             // This function determines how the console will launch.
             // Right now it's pretty basic, just checking against the available width of the window.
             // If the console was inlined on a small screen, it would cause bad UX.
@@ -198,4 +213,3 @@ if(typeof kvmService === 'object') {
 
     })(kvmService);
 }
-

--- a/composer.json
+++ b/composer.json
@@ -62,6 +62,7 @@
         "lint": "phpcs --standard=phpcs.xml -p",
         "lint-fix": "phpcbf --standard=phpcs.xml -p",
         "stan": "phpstan --memory-limit=1G",
+        "stan-baseline": "phpstan --generate-baseline --memory-limit=1G",
         "test": "phpunit -c phpunit.xml --testdox --display-warnings"
     }
 }

--- a/lib/Adaptation/ClientArea/Assets.php
+++ b/lib/Adaptation/ClientArea/Assets.php
@@ -17,10 +17,12 @@ class Assets
 
         $cssPath = OverrideHelper::asset('dist/css/client.css');
         $jsPath = OverrideHelper::asset('dist/js/client.js');
+        $cssVersion = OverrideHelper::version($cssPath);
+        $jsVersion = OverrideHelper::version($jsPath);
 
         return <<<HTML
-<link href="{$baseUrl}/modules/servers/katapult/{$cssPath}?1617183192" rel="stylesheet" type="text/css" />
-<script type="text/javascript" defer src="{$baseUrl}/modules/servers/katapult/{$jsPath}?1617183192"></script>
+<link href="{$baseUrl}/modules/servers/katapult/{$cssPath}?{$cssVersion}" rel="stylesheet" type="text/css" />
+<script type="text/javascript" defer src="{$baseUrl}/modules/servers/katapult/{$jsPath}?{$jsVersion}"></script>
 <script type="text/javascript">const knrpToken = "{$replayToken}";</script>
 HTML;
     }

--- a/lib/Helpers/OverrideHelper.php
+++ b/lib/Helpers/OverrideHelper.php
@@ -62,6 +62,17 @@ class OverrideHelper
         return self::file($file);
     }
 
+    /**
+     * Make use of the file's modified time for a pseudo-version.
+     */
+    public static function version(string $file): string
+    {
+        // Emits an E_WARNING on failure, so we suppress:
+        $mtime = @filemtime(self::path($file));
+
+        return (string) ($mtime !== false ? $mtime : '1');
+    }
+
     public static function file(string $file): string
     {
         $file = self::normaliseFile($file);

--- a/lib/Helpers/Replay.php
+++ b/lib/Helpers/Replay.php
@@ -48,7 +48,14 @@ class Replay
     public static function tokenIsValid(string $token = null): bool
     {
         if ($token === null) {
-            $token = trim($_REQUEST['knrp'] ?? '');
+            $requestToken = $_REQUEST['knrp'] ?? '';
+
+            // If a user supplies an array for the token, reject it.
+            if (is_array($requestToken)) {
+                return false;
+            }
+
+            $token = trim($requestToken);
         }
 
         if (!$token) {

--- a/lib/Helpers/Replay.php
+++ b/lib/Helpers/Replay.php
@@ -6,25 +6,23 @@ use Illuminate\Support\Str;
 
 class Replay
 {
-    public static bool $hasBooted = false;
-    public static ?string $previousToken = null;
-
-    /**
-     * @return string
-     *
-     * Generates a new token
-     */
-    protected static function generateToken(): string
+    private static function generateToken(): string
     {
         return sha1(Str::random() . microtime());
     }
 
-    /**
-     * @param string|null $token
-     * @return bool|null
-     *
-     * Checks the token is valid, but only for the client area. Else, null is returned.
-     */
+    private static function currentToken(): ?string
+    {
+        return $_SESSION['knrp_token'] ?? null;
+    }
+
+    private static function issueToken(): string
+    {
+        $_SESSION['knrp_token'] = self::generateToken();
+
+        return $_SESSION['knrp_token'];
+    }
+
     public static function tokenIsValidForClientArea(string $token = null): ?bool
     {
         if (!defined('CLIENTAREA')) {
@@ -39,57 +37,40 @@ class Replay
     }
 
     /**
-     * @param string $token
-     * @return bool
+     * Checks if a token is valid and consumes it, issuing a new one, if it was.
      *
-     * Checks whether a supplied token is valid
+     * WHMCS bootstraps the client area on 404, which means a 404 could rotate
+     * the token if we issue it on request vs clearing it when checked/consumed.
+     *
+     * This'd also be true for users loading other tabs in between attempting to
+     * run an action against this module.
      */
     public static function tokenIsValid(string $token = null): bool
     {
-        self::init();
-
-        if (!self::$previousToken) {
-            return false;
-        }
-
         if ($token === null) {
-            $token = trim($_REQUEST['knrp']) ?? null;
+            $token = trim($_REQUEST['knrp'] ?? '');
         }
 
         if (!$token) {
             return false;
         }
 
-        return $token === self::$previousToken;
-    }
-
-    /**
-     * @return string
-     *
-     * Initialises the new and previous replay tokens, returns the new token
-     */
-    public static function init(): string
-    {
-        if (self::$hasBooted) {
-            return $_SESSION['knrp_token'];
+        if ($token !== self::currentToken()) {
+            return false;
         }
 
-        self::$previousToken = $_SESSION['knrp_token'] ?? null;
+        // Issuing a new token consumes the current one. The next request will
+        // use the newly issued token.
+        self::issueToken();
 
-        $token = self::generateToken();
-
-        $_SESSION['knrp_token'] = $token;
-
-        self::$hasBooted = true;
-
-        return $token;
+        return true;
     }
 
     /**
-     * Fetches the current token
+     * The current token if there was one, or issue a new one and return it.
      */
     public static function getToken(): string
     {
-        return self::init();
+        return self::currentToken() ?? self::issueToken();
     }
 }

--- a/lib/ModuleFunction/TestConnection.php
+++ b/lib/ModuleFunction/TestConnection.php
@@ -54,7 +54,7 @@ final class TestConnection extends APIModuleCommand
         return <<<HTML
 <p>Are you...</p>
 <p>creating a new server for the first time?<br>&nbsp;&nbsp;Ignore this message and proceed to Continue Anyway.</p>
-<p>configuring an existing server?<br>&nbsp;&nbsp;You may need to configure <a href="https://docs.katapult.io/docs/dev/whmcs/Configuration/intial-setup#create-the-first-product">Katapult's API token</a>.</p>
+<p>configuring an existing server?<br>&nbsp;&nbsp;You may need to configure <a href="https://docs.katapult.io/docs/dev/whmcs/configuration/initial-setup#create-the-first-product">Katapult's API token</a>.</p>
 HTML;
     }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11,11 +11,6 @@ parameters:
 			path: lib/Helpers/ConfigurableOption.php
 
 		-
-			message: "#^Expression on left side of \\?\\? is not nullable\\.$#"
-			count: 1
-			path: lib/Helpers/Replay.php
-
-		-
 			message: "#^If condition is always true\\.$#"
 			count: 1
 			path: lib/Katapult/ParentOrganization.php

--- a/tests/Helpers/ReplayTest.php
+++ b/tests/Helpers/ReplayTest.php
@@ -113,6 +113,17 @@ class ReplayTest extends TestCase
     }
 
     #[Test]
+    public function an_array_valued_request_token_is_rejected(): void
+    {
+        // A crafted request such as ?knrp[]=x yields an array; it must be
+        // rejected rather than fatally passed to trim().
+        Replay::getToken();
+        $_REQUEST['knrp'] = ['abc', 'def'];
+
+        $this->assertFalse(Replay::tokenIsValid());
+    }
+
+    #[Test]
     public function validation_fails_when_no_token_has_been_issued(): void
     {
         // No getToken() call, so the session holds nothing to match against.

--- a/tests/Helpers/ReplayTest.php
+++ b/tests/Helpers/ReplayTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Krystal\KatapultTest\Helpers;
+
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use WHMCS\Module\Server\Katapult\Helpers\Replay;
+
+#[RunTestsInSeparateProcesses]
+#[PreserveGlobalState(false)]
+class ReplayTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Replay reads these superglobals directly; start each test clean.
+        $_SESSION = [];
+        $_REQUEST = [];
+    }
+
+    #[Test]
+    public function get_token_issues_a_token_when_none_exists(): void
+    {
+        $this->assertArrayNotHasKey('knrp_token', $_SESSION);
+
+        $token = Replay::getToken();
+
+        $this->assertNotEmpty($token);
+        $this->assertSame($token, $_SESSION['knrp_token']);
+    }
+
+    #[Test]
+    public function get_token_is_stable_across_renders(): void
+    {
+        // Rendering the token repeatedly (head hook + template, reloads, other
+        // requests) must not rotate it.
+        $first = Replay::getToken();
+        $second = Replay::getToken();
+        $third = Replay::getToken();
+
+        $this->assertSame($first, $second);
+        $this->assertSame($second, $third);
+    }
+
+    #[Test]
+    public function valid_token_is_accepted(): void
+    {
+        $token = Replay::getToken();
+
+        $this->assertTrue(Replay::tokenIsValid($token));
+    }
+
+    #[Test]
+    public function valid_token_is_consumed_and_cannot_be_reused(): void
+    {
+        $token = Replay::getToken();
+
+        $this->assertTrue(Replay::tokenIsValid($token), 'first use should succeed');
+        $this->assertFalse(Replay::tokenIsValid($token), 'replaying the same token must fail');
+    }
+
+    #[Test]
+    public function consuming_a_token_rotates_it(): void
+    {
+        $token = Replay::getToken();
+
+        Replay::tokenIsValid($token);
+
+        $this->assertNotSame($token, $_SESSION['knrp_token']);
+        $this->assertNotEmpty($_SESSION['knrp_token']);
+    }
+
+    #[Test]
+    public function a_wrong_token_is_rejected_without_consuming(): void
+    {
+        $token = Replay::getToken();
+
+        $this->assertFalse(Replay::tokenIsValid('not-the-token'));
+        // The genuine token must survive an invalid attempt.
+        $this->assertSame($token, $_SESSION['knrp_token']);
+        $this->assertTrue(Replay::tokenIsValid($token));
+    }
+
+    #[Test]
+    public function an_empty_token_is_rejected(): void
+    {
+        Replay::getToken();
+
+        $this->assertFalse(Replay::tokenIsValid(''));
+    }
+
+    #[Test]
+    public function token_is_read_from_the_request_when_not_passed(): void
+    {
+        $token = Replay::getToken();
+        $_REQUEST['knrp'] = $token;
+
+        $this->assertTrue(Replay::tokenIsValid());
+    }
+
+    #[Test]
+    public function request_token_is_trimmed(): void
+    {
+        $token = Replay::getToken();
+        $_REQUEST['knrp'] = "  {$token}  ";
+
+        $this->assertTrue(Replay::tokenIsValid());
+    }
+
+    #[Test]
+    public function validation_fails_when_no_token_has_been_issued(): void
+    {
+        // No getToken() call, so the session holds nothing to match against.
+        $this->assertFalse(Replay::tokenIsValid('anything'));
+    }
+
+    #[Test]
+    public function client_area_check_returns_null_outside_the_client_area(): void
+    {
+        // CLIENTAREA is undefined in this process, so the gate should abstain
+        // rather than validate.
+        $this->assertNull(Replay::tokenIsValidForClientArea('anything'));
+    }
+}

--- a/views/client/virtual_machines/overview.tpl
+++ b/views/client/virtual_machines/overview.tpl
@@ -78,6 +78,8 @@
 
             <h5 style="margin-top: 2rem">Console</h5>
 
+            <button class="btn btn-secondary btn-sm" type="button" id="kvm-console-fullscreen" style="margin-bottom: 0.5rem">View full screen</button>
+
             <div id="kvm-console">
 
                 <iframe title="Console" name="kvm_console"></iframe>


### PR DESCRIPTION
### Fixes

- Replay token could be consumed by a missing favicon.ico file, causing premature invalidation and preventing the next action from being possible.
- Ekosystem UI for Cloud cuts off controls and display of VM console text due to constrained width/flexbox. Workaround this.
- Cache-busting URL param was hard-coded, replaced with the file's modification time in lieu of a formalised version being available.
- Update link to docs (#49)

### Features

- Add view full screen option after launch console to make it easier to interact with the VM.

### Development

- Add test runner to Makefile and instructions to Readme for running tests.